### PR TITLE
Fix whitespace rendering in code snippets on methods

### DIFF
--- a/themes/dljs/layout/partials/apiClass.hbs
+++ b/themes/dljs/layout/partials/apiClass.hbs
@@ -19,7 +19,7 @@
   {{!-- Method List --}}
   <div class="method-list">
     {{#methods}}
-      {{> apiFunction this isMethod=true}}
+      {{~> apiFunction this isMethod=true~}}
     {{/methods}}
   </div>
 </div>


### PR DESCRIPTION
Previously rendered with extra whitespace inserted.

Fix
<img width="732" alt="screen shot 2018-03-22 at 5 26 55 pm" src="https://user-images.githubusercontent.com/26408/37799492-3d72ec3c-2df6-11e8-92b7-8839112811e1.png">

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs-website/55)
<!-- Reviewable:end -->
