### PR TITLE
make getting started more explicit for the two different paths

### DIFF
--- a/themes/dljs/layout/index.hbs
+++ b/themes/dljs/layout/index.hbs
@@ -139,7 +139,7 @@
         There are two main ways to get TensorFlow.js in your JavaScript project:
         via <a href="https://developer.mozilla.org/en-US/docs/Learn/HTML/Howto/Use_JavaScript_within_a_webpage" target="_blank">
         script tags</a> <strong>or</strong> by installing it from <a href="https://www.npmjs.com/" target="_blank">NPM</a>
-        and using a build tools like <a href="https://parceljs.org/" target="_blank">Parcel</a>,
+        and using a build tool like <a href="https://parceljs.org/" target="_blank">Parcel</a>,
         <a href="https://webpack.js.org/" target="_blank">WebPack</a>, or <a href="https://rollupjs.org/guide/en" target="_blank">Rollup</a>.
       </p>
 

--- a/themes/dljs/layout/index.hbs
+++ b/themes/dljs/layout/index.hbs
@@ -150,10 +150,12 @@
           <code class="lang-html">&lt;html&gt;
   &lt;head&gt;
     &lt;!-- Load TensorFlow.js --&gt;
-    &lt;script src=&quot;https://cdn.jsdelivr.net/npm/@tensorflow/tfjs@0.7.0&quot;&gt; &lt;/script&gt;
+    &lt;script src=&quot;https://cdn.jsdelivr.net/npm/@tensorflow/tfjs@{{latestVersion}}&quot;&gt; &lt;/script&gt;
 
     &lt;!-- Place your code in the script tag below. You can also use an external .js file --&gt;
     &lt;script&gt;
+      // Notice there is no 'import' statement. 'tf' is available on the index-page
+      // because of the script tag above.
 
       // Define a model for linear regression.
       const model = tf.sequential();

--- a/themes/dljs/layout/index.hbs
+++ b/themes/dljs/layout/index.hbs
@@ -136,29 +136,73 @@
     <div id="getting-started" class="getting-started">
       <h1>Getting Started</h1>
       <p>
-        You can use TensorFlow.js by installing it from NPM or via script tags.
+        There are two main ways to get TensorFlow.js in your JavaScript project:
+        via <a href="https://developer.mozilla.org/en-US/docs/Learn/HTML/Howto/Use_JavaScript_within_a_webpage" target="_blank">
+        script tags</a> <strong>or</strong> by installing it from <a href="https://www.npmjs.com/" target="_blank">NPM</a>
+        and using a build tools like <a href="https://parceljs.org/" target="_blank">Parcel</a>,
+        <a href="https://webpack.js.org/" target="_blank">WebPack</a>, or <a href="https://rollupjs.org/guide/en" target="_blank">Rollup</a>.
       </p>
 
-      <h3>Installation</h3>
+      <h3>via Script Tag</h3>
+      <p>Add the following code to an HTML file:</p>
+      <div class="gs-code">
+        <pre>
+          <code class="lang-html">&lt;html&gt;
+  &lt;head&gt;
+    &lt;!-- Load TensorFlow.js --&gt;
+    &lt;script src=&quot;https://cdn.jsdelivr.net/npm/@tensorflow/tfjs@0.7.0&quot;&gt; &lt;/script&gt;
+
+    &lt;!-- Place your code in the script tag below. You can also use an external .js file --&gt;
+    &lt;script&gt;
+
+      // Define a model for linear regression.
+      const model = tf.sequential();
+      model.add(tf.layers.dense({units: 1, inputShape: [1]}));
+
+      // Prepare the model for training: Specify the loss and the optimizer.
+      model.compile({loss: 'meanSquaredError', optimizer: 'sgd'});
+
+      // Generate some synthetic data for training.
+      const xs = tf.tensor2d([1, 2, 3, 4], [4, 1]);
+      const ys = tf.tensor2d([1, 3, 5, 7], [4, 1]);
+
+      // Train the model using the data.
+      model.fit(xs, ys).then(() =&gt; {
+        // Use the model to do inference on a data point the model hasn't seen before:
+        // Open the browser devtools to see the output
+        model.predict(tf.tensor2d([5], [1, 1])).print();
+      });
+    &lt;/script&gt;
+  &lt;/head&gt;
+
+  &lt;body&gt;
+  &lt;/body&gt;
+&lt;/html&gt;</code>
+        </pre>
+      </div>
+      <p>Open up that html file in your browser and the code should run!</p>
+
+      <h3>via NPM</h3>
+
+      <p>
+        Add TensorFlow.js to your project using yarn <strong>or</strong> npm. <b>Note:</b> Because
+        we use ES2017 syntax (such as `import`), this workflow assumes you are using a bundler/transpiler
+        to convert your code to something the browser understands. See our
+        <a href='https://github.com/tensorflow/tfjs-examples' target="_blank">examples</a>
+        to see how we use <a href="https://parceljs.org/" target="_blank">Parcel</a> to build
+        our code. However you are free to use any build tool that you prefer.
+      </p>
+
       <div class="gs-code">
         <pre><code class="lang-shell">yarn add @tensorflow/tfjs</code></pre>
+      </div>
+
+      <div class="gs-code">
         <pre><code class="lang-shell">npm install @tensorflow/tfjs</code></pre>
       </div>
 
-      <div class="gs-code">
-        <pre>
-          <code class="lang-html">&lt;script src="https://cdn.jsdelivr.net/npm/@tensorflow/tfjs@{{latestVersion}}"&gt;&lt;/script&gt;</code>
-        </pre>
-      </div>
+      <p>In your main js file:</p>
 
-
-      <h3>Usage</h3>
-      <p>
-        See our <a href='./tutorials'>tutorials</a>,
-        <a href='https://github.com/tensorflow/tfjs-examples' target="_blank">examples</a>
-        and <a href="./api/{{latestVersion}}/">documentation</a> for more details,
-        but let's see what it looks like to train a simple model in TensorFlow.js:
-      </p>
       <div class="gs-code">
 <pre>
   <code class="lang-js">
@@ -184,6 +228,15 @@
 </pre>
       </div>
     </div>
+
+    <p>
+      See our
+      <a href='./tutorials'>tutorials</a>,
+      <a href='https://github.com/tensorflow/tfjs-examples' target="_blank">examples</a>
+      and
+      <a href="./api/{{latestVersion}}/">documentation</a> for more details.
+    </p>
+
 
     <div class="getting-help">
       <h1>Need Help? Want to connect?</h1>


### PR DESCRIPTION
This makes the getting started instructions more explicit for the two different workflows of script tag vs npm.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs-website/123)
<!-- Reviewable:end -->
