### PR TITLE
A browser playground proposal

### DIFF
--- a/themes/dljs/helper/index.js
+++ b/themes/dljs/helper/index.js
@@ -83,7 +83,7 @@ model.fit(xs, ys).then(() => {
   // Open the browser devtools to see the output
   model.predict(tf.tensor2d([5], [1, 1])).print();
 });
-`);
+      `);
     }
   };
 };

--- a/themes/dljs/helper/index.js
+++ b/themes/dljs/helper/index.js
@@ -58,6 +58,32 @@ module.exports = function(hexo) {
 
     concat: function(a, b) {
       return a + b;
+    },
+
+    codepenHtml: function() {
+      return JSON.stringify(
+          `<h1>Try Tensorflow JS right in your browser!</h1>`);
+    },
+
+    codepenJs: function() {
+      return JSON.stringify(`// Define a model for linear regression.
+const model = tf.sequential();
+model.add(tf.layers.dense({units: 1, inputShape: [1]}));
+
+// Prepare the model for training: Specify the loss and the optimizer.
+model.compile({loss: 'meanSquaredError', optimizer: 'sgd'});
+
+// Generate some synthetic data for training.
+const xs = tf.tensor2d([1, 2, 3, 4], [4, 1]);
+const ys = tf.tensor2d([1, 3, 5, 7], [4, 1]);
+
+// Train the model using the data.
+model.fit(xs, ys).then(() => {
+  // Use the model to do inference on a data point the model hasn't seen before:
+  // Open the browser devtools to see the output
+  model.predict(tf.tensor2d([5], [1, 1])).print();
+});
+`);
     }
   };
 };

--- a/themes/dljs/layout/partials/header.hbs
+++ b/themes/dljs/layout/partials/header.hbs
@@ -18,6 +18,17 @@
     </section>
     <section class="mdc-toolbar__section mdc-toolbar__section mdc-toolbar__section--shrink-to-fit mdc-toolbar__section--align-end">
       <nav>
+        <form id="codepen-form" action="https://codepen.io/pen/define" method="POST" target="_blank">
+          <input type="hidden" name="data" value='{
+                            "title": "Try TensorFlow.js",
+                            "html": {{codepenHtml}},
+                            "js": {{codepenJs}},
+                            "editors": "1011",
+                            "layout": "top",
+                            "description": "Browser based machine learning.",
+                            "js_external": "https://cdn.jsdelivr.net/npm/@tensorflow/tfjs@{{latestVersion}}"}'>
+          <input class="mdc-button mdc-button--raised" type="submit" value="Try It Live!">
+        </form>
         <a class='button-link' href="https://github.com/tensorflow/tfjs">
           <button class="mdc-button mdc-button--raised">GitHub</button>
         </a>

--- a/themes/dljs/source/css/layout.scss
+++ b/themes/dljs/source/css/layout.scss
@@ -80,6 +80,10 @@ body {
       }
     }
 
+    #codepen-form {
+      display:inline;
+    }
+
     .mdc-toolbar__title a {
       text-decoration: none;
       margin-left: 10px;


### PR DESCRIPTION
Using codepen, the new Try it button

<img width="1624" alt="screen shot 2018-04-11 at 5 41 14 pm" src="https://user-images.githubusercontent.com/26408/38644756-a5024d70-3daf-11e8-8099-11ab89f9372c.png">

Would open

<img width="1616" alt="screen shot 2018-04-11 at 5 31 29 pm" src="https://user-images.githubusercontent.com/26408/38644763-abb1f486-3daf-11e8-9032-b85786fcf158.png">

Ready for people to edit and save to their own codepen accounts should they choose to.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs-website/128)
<!-- Reviewable:end -->
