### PR TITLE
Tutorials: Fix overflowing tables on mobile

### DIFF
--- a/source/tutorials/model-save-load.md
+++ b/source/tutorials/model-save-load.md
@@ -59,37 +59,39 @@ A few things are worth pointing out:
 The table below lists all currently supported destinations of saving models an
 their respecitve schemes and examples.
 
-<table>
-  <thead>
-    <tr>
-      <th>Saving Destination</th>
-      <th>Scheme string</th>
-      <th>Code example</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>Browser Local Storage</td>
-      <td><code>localstorage://</code></td>
-      <td><code>await model.save('localstorage://my-model-1');</code></td>
-    </tr>
-    <tr>
-      <td>Browser IndexedDB</td>
-      <td><code>indexeddb://</code></td>
-      <td><code>await model.save('indexeddb://my-model-1');</code></td>
-    </tr>
-    <tr>
-      <td>Trigger file downlads</td>
-      <td><code>downloads://</code></td>
-      <td><code>await model.save('downloads://my-model-1');</code></td>
-    </tr>
-    <tr>
-      <td>HTTP request</td>
-      <td><code>http://</code> or <code>https://</code></td>
-      <td><code>await model.save('http://model-server.domain/upload');</code></td>
-    </tr>
-  </tbody>
-</table>
+<div class="scrollable-table">
+  <table>
+    <thead>
+      <tr>
+        <th>Saving Destination</th>
+        <th>Scheme string</th>
+        <th>Code example</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td>Browser Local Storage</td>
+        <td><code>localstorage://</code></td>
+        <td><code>await model.save('localstorage://my-model-1');</code></td>
+      </tr>
+      <tr>
+        <td>Browser IndexedDB</td>
+        <td><code>indexeddb://</code></td>
+        <td><code>await model.save('indexeddb://my-model-1');</code></td>
+      </tr>
+      <tr>
+        <td>Trigger file downlads</td>
+        <td><code>downloads://</code></td>
+        <td><code>await model.save('downloads://my-model-1');</code></td>
+      </tr>
+      <tr>
+        <td>HTTP request</td>
+        <td><code>http://</code> or <code>https://</code></td>
+        <td><code>await model.save('http://model-server.domain/upload');</code></td>
+      </tr>
+    </tbody>
+  </table>
+</div>
 
 We will expand on some of the saving routes in the following sections.
 
@@ -172,37 +174,39 @@ scheme-based URL-like string argument. The string argument is symmetrical to
 `tf.Model.save` in most cases. The table below gives a summary of the supported
 loading routes:
 
-<table>
-  <thead>
-    <tr>
-    <th>Loading Route</th>
-    <th>Scheme string</th>
-    <th>Example</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>Browser Local Storage</td>
-      <td><code>localstorage://</code></td>
-      <td><code>await tf.loadModel('localstorage://my-model-1');</code></td>
-    </tr>
-    <tr>
-      <td>Browser IndexedDB</td>
-      <td><code>indexeddb://</code></td>
-      <td><code>await tf.loadModel('indexeddb://my-model-1');</code></td>
-    </tr>
-    <tr>
-      <td>Browser user-uploaded files</td>
-      <td>N/A</td>
-      <td><code>await tf.loadModel(tf.io.browserFiles([modelJSONFile, weightsFile]));</code></td>
-    </tr>
-    <tr>
-      <td>HTTP request</td>
-      <td><code>http://</code> or <code>https://</code></td>
-      <td><code>await tf.loadModel('http://model-server.domain/download/model.json');</code></td>
-    </tr>
-  </tbody>
-</table>
+<div class="scrollable-table">
+  <table>
+    <thead>
+      <tr>
+      <th>Loading Route</th>
+      <th>Scheme string</th>
+      <th>Example</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td>Browser Local Storage</td>
+        <td><code>localstorage://</code></td>
+        <td><code>await tf.loadModel('localstorage://my-model-1');</code></td>
+      </tr>
+      <tr>
+        <td>Browser IndexedDB</td>
+        <td><code>indexeddb://</code></td>
+        <td><code>await tf.loadModel('indexeddb://my-model-1');</code></td>
+      </tr>
+      <tr>
+        <td>Browser user-uploaded files</td>
+        <td>N/A</td>
+        <td><code>await tf.loadModel(tf.io.browserFiles([modelJSONFile, weightsFile]));</code></td>
+      </tr>
+      <tr>
+        <td>HTTP request</td>
+        <td><code>http://</code> or <code>https://</code></td>
+        <td><code>await tf.loadModel('http://model-server.domain/download/model.json');</code></td>
+      </tr>
+    </tbody>
+  </table>
+</div>
 
 In all the loading routes, `tf.loadModel` returns a (`Promise` of) a `tf.Model`
 object if the loading succeeds, and throw an `Error` if it fails.

--- a/themes/dljs/source/css/layout.scss
+++ b/themes/dljs/source/css/layout.scss
@@ -376,3 +376,9 @@ body {
     margin-top: 64px;
   }
 }
+
+.page-model-save-load {
+  .scrollable-table {
+    overflow-x: auto;
+  }
+}


### PR DESCRIPTION
Currently, on mobile, the tables break the view width. This PR fixes the same.

Before:

<img width="312" alt="screen shot 2018-05-20 at 10 43 46 pm" src="https://user-images.githubusercontent.com/5673050/40281441-590d9f7a-5c7f-11e8-9b9a-dd738d3542b8.png">

After:

<img width="311" alt="screen shot 2018-05-20 at 10 40 38 pm" src="https://user-images.githubusercontent.com/5673050/40281448-783a3138-5c7f-11e8-8f17-558f1cc89a8c.png">
