### PR TITLE
Correct 'low-lower linear' to 'lower-level linear'

### DIFF
--- a/source/tutorials/mnist.md
+++ b/source/tutorials/mnist.md
@@ -36,7 +36,7 @@ $ yarn watch
 The [tfjs-examples/mnist](https://github.com/tensorflow/tfjs-examples/tree/master/mnist)
 directory above is completely standalone, so you can copy it to start your own project.
 
-**NOTE:** The difference between this tutorial's code and the [tfjs-examples/mnist-core](https://github.com/tensorflow/tfjs-examples/tree/master/mnist-core) example is that here we use TensorFlow.js's higher-level APIs (`Model`, `Layer`s) to construct the model, whereas [mnist-core](https://github.com/tensorflow/tfjs-examples/tree/master/mnist-core) uses low-lower linear algebra ops to build a neural network.
+**NOTE:** The difference between this tutorial's code and the [tfjs-examples/mnist-core](https://github.com/tensorflow/tfjs-examples/tree/master/mnist-core) example is that here we use TensorFlow.js's higher-level APIs (`Model`, `Layer`s) to construct the model, whereas [mnist-core](https://github.com/tensorflow/tfjs-examples/tree/master/mnist-core) uses lower-level linear algebra ops to build a neural network.
 
 ## Data
 


### PR DESCRIPTION
There was a mistake on the documentation, saying "low-lower linear algebra". I fixed it to "lower-level linear algebra", which makes more sense.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs-website/179)
<!-- Reviewable:end -->
