### PR TITLE
Allow Promise<T> to appear in API docs.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,4 +8,4 @@ source/_data/api/local
 source/api/local
 source/_data/api_vis/local
 source/api_vis/local
-
+source/vis/local

--- a/build-scripts/doc-gen/parser.ts
+++ b/build-scripts/doc-gen/parser.ts
@@ -340,9 +340,17 @@ export function serializeMethodOrFunction(
   // getting the type. We do this because getting the full text of the
   // type node is better than using the signature return type.
   let returnType;
+  let bit = false;
   node.forEachChild(child => {
     if (ts.isTypeNode(child)) {
       returnType = child.getText();
+
+      // Special case promise return types to show the generic of the promise.
+      if (returnType.indexOf('Promise') != -1 ||
+          returnType.indexOf('TensorBuffer') != -1) {
+        console.log('RETURNING PROMSIE---------------------', returnType);
+        bit = true;
+      }
     }
   });
   if (returnType == null) {
@@ -351,6 +359,9 @@ export function serializeMethodOrFunction(
     returnType = checker.typeToString(signature.getReturnType());
   }
   returnType = util.sanitizeTypeString(returnType, identifierGenericMap);
+  if (bit) {
+    console.log(returnType);
+  }
 
   const method: DocFunction = {
     docInfo: docInfo,

--- a/build-scripts/doc-gen/parser.ts
+++ b/build-scripts/doc-gen/parser.ts
@@ -340,17 +340,9 @@ export function serializeMethodOrFunction(
   // getting the type. We do this because getting the full text of the
   // type node is better than using the signature return type.
   let returnType;
-  let bit = false;
   node.forEachChild(child => {
     if (ts.isTypeNode(child)) {
       returnType = child.getText();
-
-      // Special case promise return types to show the generic of the promise.
-      if (returnType.indexOf('Promise') != -1 ||
-          returnType.indexOf('TensorBuffer') != -1) {
-        console.log('RETURNING PROMSIE---------------------', returnType);
-        bit = true;
-      }
     }
   });
   if (returnType == null) {
@@ -359,9 +351,6 @@ export function serializeMethodOrFunction(
     returnType = checker.typeToString(signature.getReturnType());
   }
   returnType = util.sanitizeTypeString(returnType, identifierGenericMap);
-  if (bit) {
-    console.log(returnType);
-  }
 
   const method: DocFunction = {
     docInfo: docInfo,

--- a/build-scripts/doc-gen/util.ts
+++ b/build-scripts/doc-gen/util.ts
@@ -350,8 +350,8 @@ export function sanitizeTypeString(
     typeString = typeString.replace(re, identifierGenericMap[identifier]);
   });
 
-  // Remove generics.
-  typeString = typeString.replace(/(<.*>)/, '');
+  // Remove generics except Promise generics.
+  typeString = typeString.replace(/(?<!Promise)(<.+?>)/, '');
 
   return typeString;
 }


### PR DESCRIPTION
We do this by using a negative lookbehind in the regex that replaces generics.

This PR also ignores the source/vis/local directory which always shows up when running a local build.

Before:
![image](https://user-images.githubusercontent.com/1100749/53774167-6cff7c00-3ebb-11e9-8357-2bc456f05fac.png)

After (also with the change that unpacks the docs), notice return type:
![image](https://user-images.githubusercontent.com/1100749/53774207-8d2f3b00-3ebb-11e9-841e-0fffb8ade53d.png)

Non-promise generics stay the same:
![image](https://user-images.githubusercontent.com/1100749/53774218-97e9d000-3ebb-11e9-9167-8899509bf360.png)

Fixes https://github.com/tensorflow/tfjs/issues/1316


<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs-website/271)
<!-- Reviewable:end -->
