### PR TITLE
Update index.md

### DIFF
--- a/docs/tutorials/index.md
+++ b/docs/tutorials/index.md
@@ -22,7 +22,7 @@ See how to get up and running with TensorFlow.js code in the browser or Node.js.
 
 <a class="button button-white" href="/js/tutorials/setup">Get Setup</a>
 
-### Convert Pretained Models to TensorFlow.js
+### Convert Pretrained Models to TensorFlow.js
 
 Learn how to convert pretrained models from python into TensorFlow.js
 


### PR DESCRIPTION
3rd Subheading under "getting started" in js tutorials said "Convert **Pretained** Models to TensorFlow.js"
Changed 'Pretained' to 'Pretrained'
View live error here: [JS Tutorails](https://www.tensorflow.org/js/tutorials)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs-website/281)
<!-- Reviewable:end -->
