### PR TITLE
Document TypeScript gotcha for people with `strictNullChecks: true`

### DIFF
--- a/docs/tutorials/setup.md
+++ b/docs/tutorials/setup.md
@@ -144,3 +144,7 @@ model.fit(xs, ys, {
 });
   </pre>
 </section>
+
+### Typescript
+
+When using TypeScript you may need to set `skipLibCheck: true` in your `tsconfig.json` file if your project makes use of strict null checking or you will run into errors during compilation.


### PR DESCRIPTION
`strictNullChecks` is true by default in new typescript projects unless explicitly configured otherwise. This PR hopes to clarify type errors seen when using TensorFlow with TypeScript such as the one seen here https://github.com/tensorflow/tfjs/issues/1241

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs-website/287)
<!-- Reviewable:end -->
