### PR TITLE
Remove http redirect in main template

### DIFF
--- a/themes/tfjs/layout/layout.hbs
+++ b/themes/tfjs/layout/layout.hbs
@@ -38,7 +38,6 @@ limitations under the License.
   <meta name="twitter:image:height" content="431">
 
   {{#unless (isApiPage path)}}
-  <meta http-equiv="refresh" content="0; URL='https://tensorflow.org/js'" />
   <script src="https://cdn.jsdelivr.net/npm/@tensorflow/tfjs@latest"> </script>
   {{/unless}}
 


### PR DESCRIPTION
We don't need this until we actually want to set up a static mirror on another domain.