### PR TITLE
Remove stray "\" in platform_environment.md

### DIFF
--- a/docs/guide/platform_environment.md
+++ b/docs/guide/platform_environment.md
@@ -36,7 +36,7 @@ console.log(tf.getBackend());
 
 #### WebGL backend
 
-The WebGL backend, 'webgl', is currently the most powerful backend for the browser. This backend is up to 100x faster than the vanilla CPU backend. Tensors are stored as WebGL textures and mathematical operations are implemented in WebGL shaders. Here are a few useful things to know when using this backend:  \
+The WebGL backend, 'webgl', is currently the most powerful backend for the browser. This backend is up to 100x faster than the vanilla CPU backend. Tensors are stored as WebGL textures and mathematical operations are implemented in WebGL shaders. Here are a few useful things to know when using this backend:
 
 
 


### PR DESCRIPTION
There seems to be a stray "\\" character under the **WebGL backend** section in [Platform and Environment page](https://www.tensorflow.org/js/guide/platform_environment)

It is highlighted in the image below ⬇️ 

![image](https://user-images.githubusercontent.com/20588777/55599806-0948c700-5777-11e9-9eec-6df169f71724.png)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs-website/292)
<!-- Reviewable:end -->
