### PR TITLE
Remove duplicated line in tensor_operations.md

### DIFF
--- a/docs/guide/tensors_operations.md
+++ b/docs/guide/tensors_operations.md
@@ -4,8 +4,6 @@ TensorFlow.js is a framework to define and run computations using tensors in Jav
 
 ## Tensors
 
-TensorFlow.js is a framework to define and run computations using tensors in JavaScript. A *tensor* is a generalization of vectors and matrices to higher dimensions.
-
 The central unit of data in TensorFlow.js is the `tf.Tensor`: a set of values shaped into an array of one or more dimensions. `tf.Tensor`s are very similar to multidimensional arrays.
 
 A `tf.Tensor` also contains the following properties:


### PR DESCRIPTION
The line below **seems** to be _unintentionally duplicated_ under the **Tensors** section in the Tensors and Operations page, as the exact same line exists in the short description under the header **Tensors and operations**

> TensorFlow.js is a framework to define and run computations using tensors in JavaScript. A *tensor* is a generalization of vectors and matrices to higher dimensions.

![image](https://user-images.githubusercontent.com/20588777/55601312-f980b100-577d-11e9-8a3b-629bb7e466d5.png)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs-website/293)
<!-- Reviewable:end -->
