### PR TITLE
Added machinelearn.js in tutorials

### DIFF
--- a/docs/tutorials/index.md
+++ b/docs/tutorials/index.md
@@ -13,6 +13,13 @@ Built on top of TensorFlow.js, the ml5.js library provides access to machine lea
 
 <a class="button button-white" href="https://ml5js.org">Check out ml5.js</a>
 
+## Get started with ML with the easiest library in the world
+
+Are you looking for a simple yet effective general-purposed machine learning library in Javascript just like ScikitLearn?
+
+Machinelearn.js is built on top of powerful linear algebra API of TensorFlow.js, which enables both CPU and GPU acceleration for models like Logsistic Regression and Bayes Naive Classifier.
+
+<a class="button button-white" href="https://www.machinelearnjs.com/">Check out machinelearn.js</a>
 
 ## Get Setup with TensorFlow.js
 


### PR DESCRIPTION
Hi, I'd like to add a link to machinelearn.js, which is built on top of Tensorflow.js and provides an environment similar to ScikitLearn for the world of Javascript Machine Learning. I thought many newcomers would find this library useful to get started with the most basics of Machine Learning without diving straight into Deep Learning in the beginning.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs-website/298)
<!-- Reviewable:end -->
