### PR TITLE
Fix useDocsFrom for metrics in tfjs-layers

### DIFF
--- a/build-scripts/doc-gen/parser.ts
+++ b/build-scripts/doc-gen/parser.ts
@@ -118,9 +118,7 @@ function visitNode(
 
       // Static methods are top-level functions.
       if (ts.isFunctionDeclaration(node) || util.isStatic(node)) {
-        if (docInfo.heading !== undefined) {
-          subheading.symbols.push(docFunction);
-        }
+        subheading.symbols.push(docFunction);
       } else {
         // Non-static methods are class-specific.
         if (docInfo.subclasses != null) {
@@ -199,12 +197,14 @@ function visitNode(
           [];
     }
 
-    if (docInfo !== undefined && docInfo !== null &&
-        docInfo.docsForwardAlias !== undefined) {
-      globalSymbolDocMap[docInfo.docsForwardAlias] = {docs: documentation, params};
+    let globalMapKey;
+    if (docInfo != undefined && docInfo != null &&
+        docInfo.namespace != undefined) {
+      globalMapKey = docInfo.namespace + '.' + name;
     } else {
-      globalSymbolDocMap[name] = {docs: documentation, params};
+      globalMapKey = name;
     }
+    globalSymbolDocMap[globalMapKey] = {docs: documentation, params};
   }
 
   // Map interfaces to their parameter list so we can unpack configuration

--- a/build-scripts/doc-gen/util.ts
+++ b/build-scripts/doc-gen/util.ts
@@ -27,7 +27,6 @@ export interface DocInfo {
   subclasses?: string[];
   useDocsFrom?: string;
   configParamIndices?: number[];
-  docsForwardAlias?: string;
 }
 
 export function getDocDecoratorOrAnnotation(

--- a/build-scripts/doc-gen/util.ts
+++ b/build-scripts/doc-gen/util.ts
@@ -27,6 +27,7 @@ export interface DocInfo {
   subclasses?: string[];
   useDocsFrom?: string;
   configParamIndices?: number[];
+  docsForwardAlias?: string;
 }
 
 export function getDocDecoratorOrAnnotation(


### PR DESCRIPTION
BUG

This PR resolved `useDocsFrom` doesn't work for metrics in tfjs-layers (problem described in [tensorflow/tfjs#710](https://github.com/tensorflow/tfjs/issues/710)). 

~~### Note~~

~~Relative PR [tensorflow/tfjs-layers#538](https://github.com/tensorflow/tfjs-layers/pull/538)~~

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs-website/308)
<!-- Reviewable:end -->
