### PR TITLE
3.0 guides and tutorials

### DIFF
--- a/docs-prerelease/custom_ops_kernels_gradients.md
+++ b/docs-prerelease/custom_ops_kernels_gradients.md
@@ -1,0 +1,95 @@
+# Writing custom ops, kernels and gradients in TensorFlow.js
+
+
+## Overview
+
+This guide outlines the mechanisms for defining custom operations (ops), kernels and gradients in TensorFlow.js. It aims to provide an overview of the main concepts and pointers to code that demonstrate the concepts in action.
+
+
+### Who is this guide for?
+
+This is a fairly advanced guide that touches on some internals of TensorFlow.js, it may be particularly useful for the following groups of people:
+
+
+
+*   Advanced users of TensorFlow.js interested in customizing behaviour of various mathematical operations (e.g. researchers overriding existing gradient implementations or users who need to patch missing functionality in the library)
+*   Users building libraries that extend TensorFlow.js (e.g. a general linear algebra library built on top of TensorFlow.js primitives or a new TensorFlow.js backend).
+*   Users interested in contributing new ops to tensorflow.js who want to get a general overview of how these mechanisms work.
+
+This **is not** **a guide to general use** of TensorFlow.js as it goes into internal implementation mechanisms. You do not need to understand these mechanisms to use TensorFlow.js
+
+You do need to be comfortable with (or willing to try) reading TensorFlow.js source code to make the most use of this guide.
+
+
+## Terminology
+
+For this guide a few key terms are useful to describe upfront.
+
+**Operations (Ops)** — A mathematical operation on one or more tensors that produces one or more tensors as output. Ops are ‘high level’ code and can use other ops to define their logic.
+
+**Kernel** — A specific implementation of an op tied to specific hardware/platform capabilities. Kernels are ‘low level’  and backend specific. Some ops have a one-to-one mapping from op to kernel while other ops use multiple kernels.
+
+**Gradient** **/ GradFunc** — The ‘backward mode’ definition of a** op/kernel** that computes the derivative of that function with regards to some input. Gradients are ‘high level’ code (not backend specific) and can call other ops or kernels.
+
+**Kernel Registry **—** **A map from a **(kernel name, backend name) tuple to a kernel implementation**.
+
+**Gradient Registry **— A map from a **kernel name to a gradient implementation**.
+
+
+## Code organization
+
+[Operations](https://github.com/tensorflow/tfjs/tree/master/tfjs-core/src/ops) and [Gradients](https://github.com/tensorflow/tfjs/tree/master/tfjs-core/src/gradients) are defined in [tfjs-core](https://github.com/tensorflow/tfjs/tree/master/tfjs-core).
+
+Kernels are backend specific and are defined in their respective backend folders (e.g. [tfjs-backend-cpu](https://github.com/tensorflow/tfjs/tree/master/tfjs-backend-cpu/src/kernels)).
+
+Custom ops, kernels and gradients do not need to be defined inside these packages. But will often use similar symbols in their implementation.
+
+
+## Implementing Custom Ops
+
+One way to think of a custom op is just as a JavaScript function that returns some tensor output, often with tensors as input.
+
+
+
+*   Some ops can be completely defined in terms of existing ops, and should just import and call these functions directly. [Here is an example](https://github.com/tensorflow/tfjs/blob/1bec37b9364df6164a4a0ad64c29e0859382f0b4/tfjs-core/src/ops/moving_average.ts).
+*   The implementation of an op can also dispatch to backend specific kernels. This is done via `Engine.runKernel` and will be described further in the “implementing custom kernels” section. [Here is an example](https://github.com/tensorflow/tfjs/blob/1bec37b9364df6164a4a0ad64c29e0859382f0b4/tfjs-core/src/ops/sqrt.ts).
+
+
+## Implementing Custom Kernels
+
+Backend specific kernel implementations allow for optimized implementation of the logic for a given operation. Kernels are invoked by ops calling `tf.engine().runKernel()` [TODO link to signature]. A kernel implementations is defined by four things
+
+
+
+*   A kernel name.
+*   The backend the kernel is implemented in.
+*   Inputs: Tensor arguments to the kernel function.
+*   Attributes: Non-tensor arguments to the kernel function.
+
+Here is an example of [a kernel implementation](https://github.com/tensorflow/tfjs/blob/master/tfjs-backend-cpu/src/kernels/Square.ts). The conventions used to implement are backend specific and are best understood from looking at each particular backend’s implementation and documentation.
+
+Generally kernels operate at a level lower than tensors and instead directly read and write to memory that will be eventually wrapped into tensors by tfjs-core.
+
+Once a kernel is implemented it can be registered with TensorFlow.js by using `registerKernel` function from tfjs-core [TODO link to signature]. You can register a kernel for every backend you want that kernel to work in. Once registered the kernel can be invoked with `tf.engine().runKernel(...)` and TensorFlow.js will make sure to dispatch to the implementation in the current active backend.
+
+
+
+
+## Implementing Custom Gradients
+
+Gradients are generally defined for a given kernel (identified by the same kernel name used in a call to `tf.engine().runKernel(...)`). This allows tfjs-core to use a registry to look up gradient definitions for any kernel at runtime.
+
+ Implementing custom gradients are useful for:
+
+
+
+*   Adding a gradient definition that may not be present in the library
+*   Overriding an existing gradient definition to customize the gradient computation for a given kernel.
+
+You can see examples of [gradient implementations here](https://github.com/tensorflow/tfjs/tree/master/tfjs-core/src/gradients).
+
+Once you have implemented a gradient for a given call it can be registered with TensorFlow.js by using `registerGradient` function from tfjs-core [TODO link to signature]
+
+The other approach to implementing custom gradients that by-passes the gradient registry (and thus allows for computing gradients for arbitrary functions in arbitrary ways is using [tf.customGrad](https://js.tensorflow.org/api/latest/#customGrad).
+
+Here is an [example of an op within the library](https://github.com/tensorflow/tfjs/blob/f111dc03a87ab7664688011812beba4691bae455/tfjs-core/src/ops/losses/softmax_cross_entropy.ts#L64) of using customGrad

--- a/docs-prerelease/custom_ops_kernels_gradients.md
+++ b/docs-prerelease/custom_ops_kernels_gradients.md
@@ -29,7 +29,7 @@ For this guide a few key terms are useful to describe upfront.
 
 **Kernel** — A specific implementation of an op tied to specific hardware/platform capabilities. Kernels are ‘low level’  and backend specific. Some ops have a one-to-one mapping from op to kernel while other ops use multiple kernels.
 
-**Gradient** **/ GradFunc** — The ‘backward mode’ definition of a** op/kernel** that computes the derivative of that function with regards to some input. Gradients are ‘high level’ code (not backend specific) and can call other ops or kernels.
+**Gradient** **/ GradFunc** — The ‘backward mode’ definition of an **op/kernel** that computes the derivative of that function with regards to some input. Gradients are ‘high level’ code (not backend specific) and can call other ops or kernels.
 
 **Kernel Registry** - A map from a **(kernel name, backend name)** tuple to a kernel implementation.
 

--- a/docs-prerelease/custom_ops_kernels_gradients.md
+++ b/docs-prerelease/custom_ops_kernels_gradients.md
@@ -16,7 +16,7 @@ This is a fairly advanced guide that touches on some internals of TensorFlow.js,
 *   Users building libraries that extend TensorFlow.js (e.g. a general linear algebra library built on top of TensorFlow.js primitives or a new TensorFlow.js backend).
 *   Users interested in contributing new ops to tensorflow.js who want to get a general overview of how these mechanisms work.
 
-This **is not** **a guide to general use** of TensorFlow.js as it goes into internal implementation mechanisms. You do not need to understand these mechanisms to use TensorFlow.js
+This **is not** a guide to general use of TensorFlow.js as it goes into internal implementation mechanisms. You do not need to understand these mechanisms to use TensorFlow.js
 
 You do need to be comfortable with (or willing to try) reading TensorFlow.js source code to make the most use of this guide.
 
@@ -31,9 +31,9 @@ For this guide a few key terms are useful to describe upfront.
 
 **Gradient** **/ GradFunc** — The ‘backward mode’ definition of a** op/kernel** that computes the derivative of that function with regards to some input. Gradients are ‘high level’ code (not backend specific) and can call other ops or kernels.
 
-**Kernel Registry **—** **A map from a **(kernel name, backend name) tuple to a kernel implementation**.
+**Kernel Registry** - A map from a **(kernel name, backend name)** tuple to a kernel implementation.
 
-**Gradient Registry **— A map from a **kernel name to a gradient implementation**.
+**Gradient Registry** — A map from a **kernel name to a gradient implementation**.
 
 
 ## Code organization

--- a/docs-prerelease/size_optimized_bundles.md
+++ b/docs-prerelease/size_optimized_bundles.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-TensorFlow.js 3.0 brings support for building _size-optimized, production oriented browser bundles. _To put it another way we want to make it easier for you to ship less JavaScript to the browser.
+TensorFlow.js 3.0 brings support for building _size-optimized, production oriented browser bundles_. To put it another way we want to make it easier for you to ship less JavaScript to the browser.
 
 This feature is geared towards users with production use cases who would particularly benefit from shaving bytes off their payload (and are thus willing to put in the effort to achieve this). To use this feature you should be familiar with [ES Modules](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Modules), JavaScript bundling tools such as [webpack](https://webpack.js.org/) or [rollup](https://rollupjs.org/guide/en/), and concepts such as [tree-shaking/dead-code elimination](https://developers.google.com/web/fundamentals/performance/optimizing-javascript/tree-shaking).
 
@@ -28,7 +28,7 @@ In the context of this document there are a few key terms we will be using:
 
 ### Inference only graph-models
 
-The primary use case we heard about from users related to this, and are supporting in this release is that of doing **inference with _TensorFlow.js graph models. _**If you are using a _TensorFlow.js layers model, _you can convert this to the graph-model format using the [tfjs-converter](https://www.npmjs.com/package/@tensorflow/tfjs-converter). The graph model format is more efficient for the inference use case.
+The primary use case we heard about from users related to this, and are supporting in this release is that of doing **inference with _TensorFlow.js graph models_**. If you are using a _TensorFlow.js layers model_, you can convert this to the graph-model format using the [tfjs-converter](https://www.npmjs.com/package/@tensorflow/tfjs-converter). The graph model format is more efficient for the inference use case.
 
 ### Low level Tensor manipulation with tfjs-core
 

--- a/docs-prerelease/size_optimized_bundles.md
+++ b/docs-prerelease/size_optimized_bundles.md
@@ -1,0 +1,196 @@
+# Generating size-optimized browser bundles with TensorFlow.js
+
+## Overview
+
+TensorFlow.js 3.0 brings support for building _size-optimized, production oriented browser bundles. _To put it another way we want to make it easier for you to ship less JavaScript to the browser.
+
+This feature is geared towards users with production use cases who would particularly benefit from shaving bytes off their payload (and are thus willing to put in the effort to achieve this). To use this feature you should be familiar with [ES Modules](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Modules), JavaScript bundling tools such as [webpack](https://webpack.js.org/) or [rollup](https://rollupjs.org/guide/en/), and concepts such as [tree-shaking/dead-code elimination](https://developers.google.com/web/fundamentals/performance/optimizing-javascript/tree-shaking).
+
+This tutorial demonstrates how to create a custom tensorflow.js module that can be used with a bundler to generate a size optimized build for a program using tensorflow.js.
+
+
+### Terminology
+
+In the context of this document there are a few key terms we will be using:
+
+**[ES Modules](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Modules)** - **The standard JavaScript module system**. Introduced in ES6/ES2015. Identifiable by use of **import** and **export** statements.
+
+**Bundling** - Taking a set of JavaScript assets and grouping/bundling them into one or more JavaScript assets that are usable in a browser. This is the step that usually produces the final assets that are served to the browser. **_Applications will generally do their own bundling directly from transpiled library sources_.** Common **bundlers** include _rollup_ and _webpack_. The end result of bundling is a known as a **bundle** (or sometimes as a **chunk** if it is split into multiple parts)
+
+**[Tree-Shaking / Dead Code Elimination](https://developers.google.com/web/fundamentals/performance/optimizing-javascript/tree-shaking)** - Removal of code that is not used by the final written application. This is done during bundling, _typically_ in the minification step.
+
+**Operations (Ops)** - A mathematical operation on one or more tensors that produces one or more tensors as output. Ops are ‘high level’ code and can use other ops to define their logic.
+
+**Kernel** - A specific implementation of an op tied to specific hardware capabilities. Kernels are ‘low level’  and backend specific. Some ops have a one-to-one mapping from op to kernel while other ops use multiple kernels.
+
+
+## Scope and Use Cases
+
+### Inference only graph-models
+
+The primary use case we heard about from users related to this, and are supporting in this release is that of doing **inference with _TensorFlow.js graph models. _**If you are using a _TensorFlow.js layers model, _you can convert this to the graph-model format using the [tfjs-converter](https://www.npmjs.com/package/@tensorflow/tfjs-converter). The graph model format is more efficient for the inference use case.
+
+### Low level Tensor manipulation with tfjs-core
+
+The other use case we support is programs that directly use the @tensorflow/tjfs-core package for lower level tensor manipulation.
+
+
+## Our approach to custom builds
+
+Our core principles when designing this functionality includes the following:
+
+*   Make maximal use of the JavaScript module system (ESM) and allow users of TensorFlow.js to do the same.
+*   Make TensorFlow.js as tree-shakeable as possible _by existing bundlers_ (e.g. webpack, rollup, etc). This enables users to take advantage of all the capabilities of those bundlers including features like code splitting.
+*   As much as possible maintain _ease of use for users who are not as sensitive to bundle size_. This does mean that production builds will require more effort as many of the defaults in our libraries support ease of use over size optimized builds.
+
+The primary goal of our workflow is to produce a custom _JavaScript module_ for TensorFlow.js that contains only the functionality required for the program we are trying to optimize. We rely on existing bundlers to do the actual optimization.
+
+While we primarily rely on the JavaScript module system, we also provide a _custom_ _CLI tool_ to handle parts that aren’t easy to specify through the module system in user facing code. Two examples of this are:
+
+
+
+*   Model specifications stored in `model.json` files
+*   The op to backend-specific-kernel dispatching system we use.
+
+This makes generating a custom tfjs build a bit more involved than just pointing a bundler to the regular @tensorflow/tfjs package.
+
+
+## How to create size optimized custom bundles
+
+
+### Step 1: Determine which kernels your program is using
+
+**This step lets us determine all the kernels used by any models you run or pre/post-processing code given the backend you have selected.**
+
+Use tf.profile to run the parts of your application that use tensorflow.js and get the kernels. It will look something like this
+
+
+```
+const profileInfo = await tf.profile(() => {
+  // You must profile all uses of tf symbols.
+  runAllMyTfjsCode();
+});
+
+const kernelNames = profileInfo.kernelNames
+console.log(kernelNames);
+```
+
+
+Copy that list of kernels to your clipboard for the next step.
+
+> You need to profile the code using the same backend(s) that you want to use in your custom bundle.
+
+> You will need to repeat this step if your model changes or your pre/post-processing code changes.
+
+
+### Step 2. Write a configuration file for the custom tfjs module
+
+Here is an example config file.
+
+It looks like this:
+
+
+```
+{
+  "kernels": ["Reshape", "_FusedMatMul", "Identity"],
+  "backends": [
+      "cpu"
+  ],
+  "models": [
+      "./model/model.json"
+  ],
+  "outputPath": "./custom_tfjs",
+  "forwardModeOnly": true
+}
+```
+
+
+
+
+*   kernels: The list of kernels to include in the bundle. Copy this from the output of Step 1.
+*   backends: The list of backend(s) you want to include. Valid options include "cpu", "webgl" and “wasm”.
+*   models: A list of model.json files for models you load in your application. Can be empty if your program does not use tfjs\_converter to load a graph model.
+*   outputPath: A path to a folder to put the generated modules in.
+*   forwardModeOnly: Set this to false if you want to include gradients for the kernels listed prior.
+
+
+### Step 3. Generate the custom tfjs module
+
+Run the custom build tool with the config file as an argument. You need to have the **@tensorflow/tfjs** package installed in order to have access to this tool.
+
+
+```
+npx tfjs-custom-bundle  --config custom_tfjs_config.json
+```
+
+
+This will create a folder at `outputPath` with some new files.
+
+
+### Step 4. Configure your bundler to alias tfjs to the new custom module.
+
+In bundlers like webpack and rollup we can alias the existing references to tfjs modules to point to our newly generated custom tfjs modules. There are three modules that need to be aliased for maximum savings in bundle size.
+
+Here is an snippet of what that looks like in webpack ([full example here](https://github.com/tensorflow/tfjs/blob/master/e2e/custom_bundle/dense_model/webpack.config.js)):
+
+
+```
+...
+
+config.resolve = {
+  alias: {
+    '@tensorflow/tfjs$':
+        path.resolve(__dirname, './custom_tfjs/custom_tfjs.js'),
+    '@tensorflow/tfjs-core$': path.resolve(
+        __dirname, './custom_tfjs/custom_tfjs_core.js'),
+    'tensorflow/tfjs-core/dist/ops/ops_for_converter': path.resolve(
+        __dirname, './custom_tfjs/custom_ops_for_converter.js'),
+  }
+}
+
+...
+```
+
+
+And here is the equivalent code snippet for rollup ([full example here](https://github.com/tensorflow/tfjs/blob/master/e2e/custom_bundle/dense_model/rollup.config.js)):
+
+
+```
+import alias from '@rollup/plugin-alias';
+
+...
+
+alias({
+  entries: [
+    {
+      find: /@tensorflow\/tfjs$/,
+      replacement: path.resolve(__dirname, './custom_tfjs/custom_tfjs.js'),
+    },
+    {
+      find: /@tensorflow\/tfjs-core$/,
+      replacement: path.resolve(__dirname, './custom_tfjs/custom_tfjs_core.js'),
+    },
+    {
+      find: 'tensorflow/tfjs-core/dist/ops/ops_for_converter',
+      replacement: path.resolve(__dirname, './custom_tfjs/custom_ops_for_converter.js'),
+    },
+  ],
+}));
+
+...
+```
+
+
+> If your bundler does not support module aliasing, you will need to change your `import` statements to import tensorflow.js from generated `custom_tfjs.js` that was created in Step 3. Op definitions will not be tree-shaken out, but kernels still will be tree-shaken. Generally tree-shaking kernels is what provides the biggest savings in final bundle size.
+
+> If you are only using the @tensoflow/tfjs-core package, then you only need to alias that one package.
+
+
+### Step 5. Create your bundle
+
+Run your bundler (e.g. `webpack` or `rollup`) to produce your bundle. The size of the bundle should be smaller than if you run the bundler without module aliasing. You can also use visualizers like [this one](https://www.npmjs.com/package/rollup-plugin-visualizer) to see what made it into your final bundle.
+
+
+### Step 6. Test your app
+
+Make sure to test that your app is working as expected!

--- a/docs-prerelease/upgrading_to_3_0.md
+++ b/docs-prerelease/upgrading_to_3_0.md
@@ -1,0 +1,193 @@
+# Upgrading to TensorFlow.js 3.0
+
+
+## What’s changed in TensorFlow.js 3.0
+
+Release notes are [available here](https://github.com/tensorflow/tfjs/releases). A few notable user facing features include:
+
+### Custom Modules
+
+We provide support for creating custom tfjs modules to support producing size optimized browser bundles. Ship less JavaScript to your users. To learn more about this, [see this tutorial](https://docs.google.com/document/d/1-GFTKXyZQ8_L7j7XRSdWdOMClR5gVlPJfu9j1NxBxGk/edit?resourcekey=0-p69-LC9O5TUGojrMSPuLvA#heading=h.270r6grxlecj).
+
+This feature is geared towards deployment in the browser, however enabling this capability motivates some of the changes described below.
+
+
+### ES2017 Code
+
+In addition to some pre-compile bundles, **the main way that we now ship our code to NPM is as [ES Modules](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Modules) with [ES2017 syntax](https://2ality.com/2016/02/ecmascript-2017.html)**. This allows developers to take advantage of [modern JavaScript features](https://web.dev/publish-modern-javascript/) and have greater control over what they ship to their end users.
+
+Our package.json `module` entry point to individual library files in ES2017 format (i.e. not a bundle). This enables tree shaking and greater developer control over downstream transpilation.
+
+We do provide a few alternate formats as pre-compiled bundles to support legacy browsers and other module systems. They follow the naming convention described in the table below and you can load them from popular CDNs such as JsDelivr and Unpkg.
+
+
+<table>
+  <tr>
+   <td>File Name
+   </td>
+   <td>Module Format
+   </td>
+   <td>Language Version
+   </td>
+  </tr>
+  <tr>
+   <td>tf[-package].[min].js*
+   </td>
+   <td>UMD
+   </td>
+   <td>ES5
+   </td>
+  </tr>
+  <tr>
+   <td>tf[-package].es2017.[min].js
+   </td>
+   <td>UMD
+   </td>
+   <td>ES2017
+   </td>
+  </tr>
+  <tr>
+   <td>tf[-package].node.js**
+   </td>
+   <td>CommonJS
+   </td>
+   <td>ES5
+   </td>
+  </tr>
+  <tr>
+   <td>tf[-package].es2017.fesm.[min].js
+   </td>
+   <td>ESM (Single flat file)
+   </td>
+   <td>ES2017
+   </td>
+  </tr>
+  <tr>
+   <td>index.js***
+   </td>
+   <td>ESM
+   </td>
+   <td>ES2017
+   </td>
+  </tr>
+</table>
+
+
+\* [package] refers to names like core/converter/layers for subpackages of the main tf.js package. [min] describes where we provide minified files in addition to unminified files.
+
+\*\* Our package.json `main` entry points to this file.
+
+\*\*\* Our package.json `module` entry points to this file.
+
+If you are using tensorflow.js via npm and you are using bundler, you may need to adjust your bundler configuration to make sure it can either consume the ES2017 modules or point it to another one of the entries in out package.json.
+
+
+### @tensorflow/tfjs-core is slimmer by default
+
+To enable better [tree-shaking](https://developers.google.com/web/fundamentals/performance/optimizing-javascript/tree-shaking) we no longer include the chaining/fluent api on tensors by default in @tensorflow/tfjs-core. We recommend using operations (ops) directly to get the smallest bundle. We provide an import `import '@tensorflow/tfjs-core/dist/public/chained_ops/register_all_chained_ops';` that restores the chaining api.
+
+We also no longer register gradients for kernels by default. If you want gradient/training support you can `import '@tensorflow/tfjs-core/dist/register_all_gradients';`
+
+**Note: If you are using @tensorflow/tfjs or @tensorflow/tfjs-layers or any of the other higher level packages, this is done for you automatically.**
+
+
+### Code Reorganization, kernel & gradient registries
+
+We have re-organized our code to make it easier to both contribute ops and kernels as well as implement custom ops, kernels and gradients. [See this guide for more information](https://docs.google.com/document/d/1cFIjNa5YArApTY5BwLyuBu5-aHRGgS0cGu6_brQWieI/edit?resourcekey=0-oYyeDC7HlutHeHVVTN9vqA).
+
+
+### Breaking Changes
+
+A full list of breaking changes can be found [here](https://github.com/tensorflow/tfjs/releases), but they include removal of all \*Strict ops like mulStrict or addStrict.
+
+
+## Upgrading Code from 2.x
+
+
+### Users of @tensorflow/tfjs
+
+Address any breaking changes listed here (https://github.com/tensorflow/tfjs/releases)
+
+
+### Users of @tensorflow/tfjs-core
+
+Address any breaking changes listed here (https://github.com/tensorflow/tfjs/releases), then do the following:
+
+
+#### Add chained op augmentors or use ops directly
+
+Rather than
+
+
+```
+import * as tf from '@tensorflow/tfjs-core';
+import '@tensorflow/tfjs-backend-webgl';
+
+const a = tf.tensor([1,2,3,4]);
+const b = a.sum(); // this is a 'chained' op.
+```
+
+
+You need to do
+
+
+```
+import * as tf from '@tensorflow/tfjs-core';
+import '@tensorflow/tfjs-backend-webgl';
+import '@tensorflow/tfjs-core/dist/public/chained_ops/sum'; // add the 'sum' chained op to all tensors
+
+const a = tf.tensor([1,2,3,4]);
+const b = a.sum();
+```
+
+
+You can also import all the chaining/fluent api with the following import
+
+
+```
+import '@tensorflow/tfjs-core/dist/public/chained_ops/register_all_chained_ops';
+```
+
+
+Alternatively you can use the op directly (you could use named imports here too)
+
+
+```
+import * as tf from '@tensorflow/tfjs-core';
+import '@tensorflow/tfjs-backend-webgl';
+
+const a = tf.tensor([1,2,3,4]);
+const b = tf.sum(a);
+```
+
+
+
+#### Import initialization code
+
+If you are exclusively using named imports (instead of `import *  as ...`) then in some cases you may need to do
+
+
+```
+import @tensorflow/tfjs-core
+```
+
+
+near the top of your program, this prevents aggressive tree-shakers from dropping any necessary initialization.
+
+
+## Upgrading Code from 1.x
+
+
+### Users of @tensorflow/tfjs
+
+Address any breaking changes listed [here](https://github.com/tensorflow/tfjs/releases/tag/tfjs-v2.0.0). Then follow the instructions for upgrading from 2.x
+
+
+### Users of @tensorflow/tfjs-core
+
+Address any breaking changes listed [here](https://github.com/tensorflow/tfjs/releases/tag/tfjs-v2.0.0), select a backend as described below and then follow the steps for upgrading from 2.x
+
+
+#### Selecting a backend(s)
+
+In TensorFlow.js 2.0 we removed the cpu and webgl backends into their own packages. See [@tensorflow/tfjs-backend-cpu](https://www.npmjs.com/package/@tensorflow/tfjs-backend-cpu), [@tensorflow/tfjs-backend-webgl](https://www.npmjs.com/package/@tensorflow/tfjs-backend-webgl), [@tensorflow/tfjs-backend-wasm](https://www.npmjs.com/package/@tensorflow/tfjs-backend-wasm) for instructions on how to include those backends.

--- a/docs-prerelease/upgrading_to_3_0.md
+++ b/docs-prerelease/upgrading_to_3_0.md
@@ -88,7 +88,7 @@ To enable better [tree-shaking](https://developers.google.com/web/fundamentals/p
 
 We also no longer register gradients for kernels by default. If you want gradient/training support you can `import '@tensorflow/tfjs-core/dist/register_all_gradients';`
 
-**Note: If you are using @tensorflow/tfjs or @tensorflow/tfjs-layers or any of the other higher level packages, this is done for you automatically.**
+> Note: If you are using @tensorflow/tfjs or @tensorflow/tfjs-layers or any of the other higher level packages, this is done for you automatically.
 
 
 ### Code Reorganization, kernel & gradient registries


### PR DESCRIPTION
Add new guides and tutorials to website repo.

These are markdown versions of the docs in our team drive.

They are going into a `docs-prerelease` folder so that they can be linked to from the release ntoes and publicaly viewable. When the final release goes out these will be moved into the `docs` folder which automatically syncs with the tensorflow web site.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs-website/398)
<!-- Reviewable:end -->
