### PR TITLE
Minor fixes for doc-gen

### DIFF
--- a/build-scripts/build-task-api.ts
+++ b/build-scripts/build-task-api.ts
@@ -45,6 +45,8 @@ const libs: LibraryInfo[] = [
     // Add more as needed.
     allowedDeclarationFileSubpaths: [
       'tasks/node_modules/@tensorflow-models/mobilenet',
+      'tasks/node_modules/@tensorflow-models/coco-ssd',
+      'tasks/node_modules/@tensorflow-models/deeplab',
     ],
   },
 ];

--- a/build-scripts/build_api_helpers.ts
+++ b/build-scripts/build_api_helpers.ts
@@ -75,7 +75,7 @@ export function generateDocs(libs: LibraryInfo[]): string[] {
       out: outputPath,
       allowedDeclarationFileSubpaths: lib.allowedDeclarationFileSubpaths ?
           lib.allowedDeclarationFileSubpaths.join(',') :
-          '',
+          '""',
     };
 
     const docGenCommand = `ts-node --project tsconfig.json ${docGenScript} ` +

--- a/source/_data/api_tasks/skeleton.json
+++ b/source/_data/api_tasks/skeleton.json
@@ -43,5 +43,21 @@
       "The task of classifying images into a preset of labels."
     ],
     "subheadings": []
+  },
+  {
+    "name": "Image Segmentation",
+    "description": [
+      "<p>",
+      "The task of predicting associated class for each pixel of an image."
+    ],
+    "subheadings": []
+  },
+  {
+    "name": "Object Detection",
+    "description": [
+      "<p>",
+      "The task of localizing and identifing multiple objects in a single image."
+    ],
+    "subheadings": []
   }
 ]


### PR DESCRIPTION
- Add cocossd and deeplab to the declaration file allow list.
- Set default value of the `allowedDeclarationFileSubpaths` flag to empty string with the quotes. Without doing this, the command line tool will consider it as missing argument.
- Add skeleton for image segmentation and object detection task.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs-website/423)
<!-- Reviewable:end -->
