### PR TITLE
Enable API doc generation from a file and from variables

### DIFF
--- a/build-scripts/build-api.ts
+++ b/build-scripts/build-api.ts
@@ -76,7 +76,7 @@ const flagFiles = [
 ];
 
 console.log(`********* Generating Docs *********`);
-const outputPaths = [...generateDocs(libs, false), ...generateDocs(flagFiles, true)];
+const outputPaths = [...generateDocs(libs, false, false), ...generateDocs(flagFiles, true, true)];
 
 console.log(`********* Merging docs *********`);
 const bundlePath = commander.bundle && path.resolve(commander.bundle) ||

--- a/build-scripts/build-api.ts
+++ b/build-scripts/build-api.ts
@@ -45,13 +45,6 @@ const libs = [
     outputFolder: versionedDocsFolder
   },
   {
-    packageName: 'tfjs-backend-webgl',
-    fileName: 'src/flags_webgl.ts',
-    github: `https://github.com/tensorflow/tfjs/tree/${tfjsTag}/tfjs-backend-webgl`,
-    version: tfjsVersion,
-    outputFolder: versionedDocsFolder
-  },
-  {
     packageName: 'tfjs-layers',
     github: `https://github.com/tensorflow/tfjs/tree/${tfjsTag}/tfjs-layers`,
     version: tfjsVersion,
@@ -72,8 +65,18 @@ const libs = [
   }
 ];
 
+const flagFiles = [
+  {
+    packageName: 'tfjs-backend-webgl',
+    fileName: 'src/flags_webgl.ts',
+    github: `https://github.com/tensorflow/tfjs/tree/${tfjsTag}/tfjs-backend-webgl`,
+    version: tfjsVersion,
+    outputFolder: versionedDocsFolder
+  },
+];
+
 console.log(`********* Generating Docs *********`);
-const outputPaths = generateDocs(libs);
+const outputPaths = [...generateDocs(libs, false), ...generateDocs(flagFiles, true)];
 
 console.log(`********* Merging docs *********`);
 const bundlePath = commander.bundle && path.resolve(commander.bundle) ||

--- a/build-scripts/build-api.ts
+++ b/build-scripts/build-api.ts
@@ -45,6 +45,13 @@ const libs = [
     outputFolder: versionedDocsFolder
   },
   {
+    packageName: 'tfjs-backend-webgl',
+    fileName: 'src/flags_webgl.ts',
+    github: `https://github.com/tensorflow/tfjs/tree/${tfjsTag}/tfjs-backend-webgl`,
+    version: tfjsVersion,
+    outputFolder: versionedDocsFolder
+  },
+  {
     packageName: 'tfjs-layers',
     github: `https://github.com/tensorflow/tfjs/tree/${tfjsTag}/tfjs-layers`,
     version: tfjsVersion,

--- a/build-scripts/build_api_helpers.ts
+++ b/build-scripts/build_api_helpers.ts
@@ -79,14 +79,14 @@ export function generateDocs(libs: LibraryInfo[]): string[] {
       allowedDeclarationFileSubpaths: lib.allowedDeclarationFileSubpaths ?
           lib.allowedDeclarationFileSubpaths.join(',') :
           '""',
-      type: lib.fileName == null ? 'package' : 'file'
+      isFile: lib.fileName != null
     };
 
     const docGenCommand = `ts-node --project tsconfig.json ${docGenScript} ` +
         `--in ${opts.input} --package ${opts.pkg} --src ${opts.src} --github ${
                               opts.github} --out ${opts.out} --repo ${
                               opts.repo} --allowed-declaration-file-subpaths ${
-                              opts.allowedDeclarationFileSubpaths} --type ${opts.type}`;
+                              opts.allowedDeclarationFileSubpaths} ${opts.isFile ? '--isFile' : ''}`;
 
     // Prep the component. If "local" has been passed in then we do nothing
     // to what is in libs. Else we want to check out a tag that correspond to

--- a/build-scripts/build_api_helpers.ts
+++ b/build-scripts/build_api_helpers.ts
@@ -58,13 +58,14 @@ export interface Manifest {
  * Parse the libraries and generate the JSON with symbols and docs.
  * @param libs
  */
-export function generateDocs(libs: LibraryInfo[]): string[] {
+export function generateDocs(libs: LibraryInfo[], isFlagFile: boolean = false): string[] {
   const docGenScript = 'build-scripts/doc-gen/make-api.ts';
 
   const outputPaths = [];
   libs.forEach(lib => {
     const outputPath =
-        path.resolve(`${lib.outputFolder}/${lib.packageName}.json`);
+        path.resolve(`${lib.outputFolder}/${lib.packageName}${
+          isFlagFile ? '_flags' : ''}.json`);
 
     const repoName = lib.repoName || 'tfjs';
     const opts = {
@@ -79,14 +80,17 @@ export function generateDocs(libs: LibraryInfo[]): string[] {
       allowedDeclarationFileSubpaths: lib.allowedDeclarationFileSubpaths ?
           lib.allowedDeclarationFileSubpaths.join(',') :
           '""',
-      isFile: lib.fileName != null
+      isFile: isFlagFile,
+      parseFlags: isFlagFile
     };
 
     const docGenCommand = `ts-node --project tsconfig.json ${docGenScript} ` +
         `--in ${opts.input} --package ${opts.pkg} --src ${opts.src} --github ${
                               opts.github} --out ${opts.out} --repo ${
                               opts.repo} --allowed-declaration-file-subpaths ${
-                              opts.allowedDeclarationFileSubpaths} ${opts.isFile ? '--isFile' : ''}`;
+                              opts.allowedDeclarationFileSubpaths} ${
+                              opts.isFile ? '--isFile' : ''} ${
+                              opts.parseFlags ? '--parseFlags' : ''}`;
 
     // Prep the component. If "local" has been passed in then we do nothing
     // to what is in libs. Else we want to check out a tag that correspond to

--- a/build-scripts/build_api_helpers.ts
+++ b/build-scripts/build_api_helpers.ts
@@ -27,6 +27,7 @@ export interface LibraryInfo {
   // The name the repo. Default to `tfjs`.
   // This will be used to locate the repo dir under lib/.
   repoName?: string;
+  fileName?: string;
   packageName: string;  // path to the library within the website folder
   github: string;       // github url for library
   version: string;      // the version to checkout || 'local' to use repo as is.
@@ -67,7 +68,9 @@ export function generateDocs(libs: LibraryInfo[]): string[] {
 
     const repoName = lib.repoName || 'tfjs';
     const opts = {
-      input: path.resolve(`libs/${repoName}/${lib.packageName}/src/index.ts`),
+      input: lib.fileName == null ?
+        path.resolve(`libs/${repoName}/${lib.packageName}/src/index.ts`) :
+        path.resolve(`libs/${repoName}/${lib.packageName}/${lib.fileName}`),
       pkg: path.resolve(`libs/${repoName}/${lib.packageName}/package.json`),
       src: path.resolve(`libs/${repoName}/${lib.packageName}/src/`),
       repo: path.resolve(`libs/${repoName}/${lib.packageName}/`),
@@ -76,13 +79,14 @@ export function generateDocs(libs: LibraryInfo[]): string[] {
       allowedDeclarationFileSubpaths: lib.allowedDeclarationFileSubpaths ?
           lib.allowedDeclarationFileSubpaths.join(',') :
           '""',
+      type: lib.fileName == null ? 'package' : 'file'
     };
 
     const docGenCommand = `ts-node --project tsconfig.json ${docGenScript} ` +
         `--in ${opts.input} --package ${opts.pkg} --src ${opts.src} --github ${
                               opts.github} --out ${opts.out} --repo ${
                               opts.repo} --allowed-declaration-file-subpaths ${
-                              opts.allowedDeclarationFileSubpaths}`;
+                              opts.allowedDeclarationFileSubpaths} --type ${opts.type}`;
 
     // Prep the component. If "local" has been passed in then we do nothing
     // to what is in libs. Else we want to check out a tag that correspond to

--- a/build-scripts/build_api_helpers.ts
+++ b/build-scripts/build_api_helpers.ts
@@ -109,7 +109,8 @@ export function generateDocs(libs: LibraryInfo[], isFlagFile: boolean = false): 
          `Error checkout out ${lib.version} for ${lib.packageName}`);
     }
 
-    console.log(`********* Generating docs for ${lib.packageName} *********`);
+    console.log(`********* Generating docs for ${lib.packageName}${
+      isFlagFile ? '\'s flags' : ''} *********`);
 
     sh('pwd', `Error pwd`);
 

--- a/build-scripts/doc-gen/make-api.ts
+++ b/build-scripts/doc-gen/make-api.ts
@@ -32,7 +32,8 @@ commander.option('--in <path>', 'main source entry')
     .option('--github <url>', 'Github repository URL')
     .option('--out <path>', 'Output Path')
     .option('--allowed-declaration-file-subpaths <paths>',
-        'Sub paths of allowed declaration files, separated by ","')
+    'Sub paths of allowed declaration files, separated by ","')
+    .option('--type <string>', `The type of input, 'file' or 'package'`, 'package')
     .parse(process.argv);
 
 const options = commander.opts();
@@ -44,6 +45,7 @@ console.log('make-api params', [
   options.github,
   options.out,
   options.allowedDeclarationFileSubpaths,
+  options.type
 ])
 
 const allParamsPresent = [
@@ -69,10 +71,18 @@ mkdirp(outputDir, (err: any) => {
 });
 
 // Parse the library for docs.
-const repoDocsAndMetadata = parser.parse(
+let repoDocsAndMetadata;
+if (options.type === 'file') {
+  repoDocsAndMetadata = parser.parseFile(
     options.in, options.src, options.repo, options.github,
     options.allowedDeclarationFileSubpaths.split(',').filter(
         ele => ele !== ''));
+} else {
+  repoDocsAndMetadata = parser.parseProgram(
+    options.in, options.src, options.repo, options.github,
+    options.allowedDeclarationFileSubpaths.split(',').filter(
+        ele => ele !== ''));
+}
 
 // Write the JSON.
 mkdirp.sync(path.dirname(options.out));

--- a/build-scripts/doc-gen/make-api.ts
+++ b/build-scripts/doc-gen/make-api.ts
@@ -26,14 +26,16 @@ import * as parser from './parser';
 import * as util from './util';
 
 commander.option('--in <path>', 'main source entry')
-    .option('--isFile', `If 'in' is a file. If not set, 'in' is considered as a package`)
+    .option('--isFile', `If 'in' is a file. If not set, ` +
+        `'in' is considered as a package`)
     .option('--package <path>', 'Package.json path')
     .option('--src <path>', 'Path to src folder of repo')
     .option('--repo <path>', 'Path to repo')
     .option('--github <url>', 'Github repository URL')
     .option('--out <path>', 'Output Path')
     .option('--allowed-declaration-file-subpaths <paths>',
-    'Sub paths of allowed declaration files, separated by ","')
+        'Sub paths of allowed declaration files, separated by ","')
+    .option('--parseFlags', 'If set, the parser will traverse variables too.')
     .parse(process.argv);
 
 const options = commander.opts();
@@ -45,7 +47,8 @@ console.log('make-api params', [
   options.src,
   options.github,
   options.out,
-  options.allowedDeclarationFileSubpaths
+  options.allowedDeclarationFileSubpaths,
+  options.parseFlags
 ])
 
 const allParamsPresent = [
@@ -74,7 +77,7 @@ mkdirp(outputDir, (err: any) => {
 let repoDocsAndMetadata = parser.parse(
   options.in, options.src, options.repo, options.github,
   options.allowedDeclarationFileSubpaths.split(',').filter(
-      ele => ele !== ''), options.isFile);
+      ele => ele !== ''), options.isFile, options.parseFlags);
 
 // Write the JSON.
 mkdirp.sync(path.dirname(options.out));

--- a/build-scripts/doc-gen/make-api.ts
+++ b/build-scripts/doc-gen/make-api.ts
@@ -35,7 +35,7 @@ commander.option('--in <path>', 'main source entry')
     .option('--out <path>', 'Output Path')
     .option('--allowed-declaration-file-subpaths <paths>',
         'Sub paths of allowed declaration files, separated by ","')
-    .option('--parseFlags', 'If set, the parser will traverse variables too.')
+    .option('--parseVariables', 'If set, the parser will traverse variables too.')
     .parse(process.argv);
 
 const options = commander.opts();
@@ -48,7 +48,7 @@ console.log('make-api params', [
   options.github,
   options.out,
   options.allowedDeclarationFileSubpaths,
-  options.parseFlags
+  options.parseVariables
 ])
 
 const allParamsPresent = [
@@ -77,7 +77,7 @@ mkdirp(outputDir, (err: any) => {
 let repoDocsAndMetadata = parser.parse(
   options.in, options.src, options.repo, options.github,
   options.allowedDeclarationFileSubpaths.split(',').filter(
-      ele => ele !== ''), options.isFile, options.parseFlags);
+      ele => ele !== ''), options.isFile, options.parseVariables);
 
 // Write the JSON.
 mkdirp.sync(path.dirname(options.out));

--- a/build-scripts/doc-gen/make-api.ts
+++ b/build-scripts/doc-gen/make-api.ts
@@ -26,6 +26,7 @@ import * as parser from './parser';
 import * as util from './util';
 
 commander.option('--in <path>', 'main source entry')
+    .option('--isFile', `If 'in' is a file. If not set, 'in' is considered as a package`)
     .option('--package <path>', 'Package.json path')
     .option('--src <path>', 'Path to src folder of repo')
     .option('--repo <path>', 'Path to repo')
@@ -33,19 +34,18 @@ commander.option('--in <path>', 'main source entry')
     .option('--out <path>', 'Output Path')
     .option('--allowed-declaration-file-subpaths <paths>',
     'Sub paths of allowed declaration files, separated by ","')
-    .option('--type <string>', `The type of input, 'file' or 'package'`, 'package')
     .parse(process.argv);
 
 const options = commander.opts();
 
 console.log('make-api params', [
   options.in,
+  options.isFile,
   options.package,
   options.src,
   options.github,
   options.out,
-  options.allowedDeclarationFileSubpaths,
-  options.type
+  options.allowedDeclarationFileSubpaths
 ])
 
 const allParamsPresent = [
@@ -71,18 +71,10 @@ mkdirp(outputDir, (err: any) => {
 });
 
 // Parse the library for docs.
-let repoDocsAndMetadata;
-if (options.type === 'file') {
-  repoDocsAndMetadata = parser.parseFile(
-    options.in, options.src, options.repo, options.github,
-    options.allowedDeclarationFileSubpaths.split(',').filter(
-        ele => ele !== ''));
-} else {
-  repoDocsAndMetadata = parser.parseProgram(
-    options.in, options.src, options.repo, options.github,
-    options.allowedDeclarationFileSubpaths.split(',').filter(
-        ele => ele !== ''));
-}
+let repoDocsAndMetadata = parser.parse(
+  options.in, options.src, options.repo, options.github,
+  options.allowedDeclarationFileSubpaths.split(',').filter(
+      ele => ele !== ''), options.isFile);
 
 // Write the JSON.
 mkdirp.sync(path.dirname(options.out));

--- a/build-scripts/doc-gen/parser.ts
+++ b/build-scripts/doc-gen/parser.ts
@@ -81,7 +81,8 @@ const IN_NAMESPACE_JSDOC = 'innamespace';
  */
 export function parse(
     programRoot: string, srcRoot: string, repoPath: string, githubRoot: string,
-    allowedDeclarationFileSubpaths: string[], isFile: boolean): RepoDocsAndMetadata {
+    allowedDeclarationFileSubpaths: string[], isFile: boolean, parseFlags: boolean):
+    RepoDocsAndMetadata {
   if (!fs.existsSync(programRoot)) {
     throw new Error(
         `Program root ${programRoot} does not exist. Please run this script ` +

--- a/build-scripts/doc-gen/parser.ts
+++ b/build-scripts/doc-gen/parser.ts
@@ -81,7 +81,7 @@ const IN_NAMESPACE_JSDOC = 'innamespace';
  */
 export function parse(
     programRoot: string, srcRoot: string, repoPath: string, githubRoot: string,
-    allowedDeclarationFileSubpaths: string[]): RepoDocsAndMetadata {
+    allowedDeclarationFileSubpaths: string[], isFile: boolean): RepoDocsAndMetadata {
   if (!fs.existsSync(programRoot)) {
     throw new Error(
         `Program root ${programRoot} does not exist. Please run this script ` +
@@ -112,7 +112,11 @@ export function parse(
 
   // Visit all the nodes that are transitively linked from the source
   // root.
-  for (const sourceFile of program.getSourceFiles()) {
+  let sourceFiles = program.getSourceFiles();
+  if (isFile) {
+    sourceFiles.filter(e => e.fileName === programRoot);
+  }
+  for (const sourceFile of sourceFiles) {
     if (!sourceFile.isDeclarationFile ||
         allowedDeclarationFileSubpaths.some(
             allowedPath => sourceFile.fileName.includes(allowedPath))) {

--- a/build-scripts/doc-gen/parser.ts
+++ b/build-scripts/doc-gen/parser.ts
@@ -114,7 +114,7 @@ export function parse(
   // root.
   let sourceFiles = program.getSourceFiles();
   if (isFile) {
-    sourceFiles.filter(e => e.fileName === programRoot);
+    sourceFiles = sourceFiles.filter(e => e.fileName === programRoot);
   }
   for (const sourceFile of sourceFiles) {
     if (!sourceFile.isDeclarationFile ||

--- a/build-scripts/doc-gen/util.ts
+++ b/build-scripts/doc-gen/util.ts
@@ -31,7 +31,7 @@ export interface DocInfo {
 
 export function getDocDecoratorOrAnnotation(
     checker: ts.TypeChecker,
-    node: ts.MethodDeclaration|ts.ClassDeclaration|ts.FunctionDeclaration,
+    node: ts.MethodDeclaration|ts.ClassDeclaration|ts.FunctionDeclaration|ts.VariableDeclaration,
     annotationName: string): DocInfo {
   let docInfo: DocInfo;
   // Try to parse decorators.
@@ -331,7 +331,7 @@ export function isStatic(node: ts.MethodDeclaration): boolean {
 export function getJsdoc(
     checker: ts.TypeChecker,
     node: ts.InterfaceDeclaration|ts.TypeAliasDeclaration|ts.ClassDeclaration|
-    ts.EnumDeclaration|ts.FunctionDeclaration|ts.MethodDeclaration,
+    ts.EnumDeclaration|ts.FunctionDeclaration|ts.MethodDeclaration|ts.VariableDeclaration,
     tag: string): string {
   const symbol = checker.getSymbolAtLocation(node.name);
   const docs = symbol.getDocumentationComment(checker);
@@ -455,6 +455,8 @@ export function foreachDocFunction(
           symbol.methods.forEach(method => {
             fn(method);
           });
+        } else if (untypedSymbol['isFlag']) {
+          return;
         } else {
           fn(untypedSymbol as DocFunction);
         }
@@ -571,7 +573,9 @@ export function linkSymbols(
                  symbol.namespace + '.' :
                  '');
 
-        if (toplevelNamespace.length > 0) {
+        if (symbol['isFlag']) {
+          symbol.displayName = symbol.symbolName
+        } else if (toplevelNamespace.length > 0) {
           symbol.displayName =
               toplevelNamespace + '.' + namespace + symbol.symbolName;
         } else {

--- a/build-scripts/doc-gen/util.ts
+++ b/build-scripts/doc-gen/util.ts
@@ -455,7 +455,7 @@ export function foreachDocFunction(
           symbol.methods.forEach(method => {
             fn(method);
           });
-        } else if (untypedSymbol['isFlag']) {
+        } else if (untypedSymbol['isVariable']) {
           return;
         } else {
           fn(untypedSymbol as DocFunction);
@@ -573,7 +573,7 @@ export function linkSymbols(
                  symbol.namespace + '.' :
                  '');
 
-        if (symbol['isFlag']) {
+        if (symbol['isVariable']) {
           symbol.displayName = symbol.symbolName
         } else if (toplevelNamespace.length > 0) {
           symbol.displayName =

--- a/build-scripts/doc-gen/view.ts
+++ b/build-scripts/doc-gen/view.ts
@@ -41,7 +41,7 @@ export interface DocSubheading {
   symbols?: DocSymbol[];
 }
 
-export type DocSymbol = DocFunction|DocClass;
+export type DocSymbol = DocFunction|DocClass|DocFlag;
 
 export interface DocClass {
   docInfo: DocInfo;
@@ -98,4 +98,20 @@ export interface DocExtraType {
   description: string;
   symbol: string;
   params?: DocFunctionParam[];
+}
+
+export interface DocFlag {
+  docInfo: DocInfo;
+
+  symbolName: string;
+  namespace: string;
+  documentation: string;
+  fileName: string;
+  githubUrl: string;
+
+  isFlag: true;
+
+  // Filled in by the linker.
+  displayName?: string;
+  urlHash?: string;
 }

--- a/build-scripts/doc-gen/view.ts
+++ b/build-scripts/doc-gen/view.ts
@@ -41,7 +41,7 @@ export interface DocSubheading {
   symbols?: DocSymbol[];
 }
 
-export type DocSymbol = DocFunction|DocClass|DocFlag;
+export type DocSymbol = DocFunction|DocClass|DocVariable;
 
 export interface DocClass {
   docInfo: DocInfo;
@@ -100,7 +100,7 @@ export interface DocExtraType {
   params?: DocFunctionParam[];
 }
 
-export interface DocFlag {
+export interface DocVariable {
   docInfo: DocInfo;
 
   symbolName: string;
@@ -109,7 +109,7 @@ export interface DocFlag {
   fileName: string;
   githubUrl: string;
 
-  isFlag: true;
+  isVariable: true;
 
   // Filled in by the linker.
   displayName?: string;


### PR DESCRIPTION
This PR enables `yarn build-api` command to parse variables declared in [flagFiles](https://github.com/tensorflow/tfjs-website/pull/476/files#diff-f10d967e083e31273927d31911a476b660894628514efb9f71d0adc4676a01d8R68) and also enables it to parse single file without dependencies.

Specifically, for each file declared in [flagFiles](https://github.com/tensorflow/tfjs-website/pull/476/files#diff-f10d967e083e31273927d31911a476b660894628514efb9f71d0adc4676a01d8R68), the parser will traverse all `node`s if `ts.isVariableDeclaration(node)`.

For example, if webgl's flag file is declared in [flagFiles](https://github.com/tensorflow/tfjs-website/pull/476/files#diff-f10d967e083e31273927d31911a476b660894628514efb9f71d0adc4676a01d8R68), the following codes in the flag file
```js
/**
 * Whether we will use shapes uniforms.
 *
 * @doc {heading: 'Flags', subheading: 'WebGL'}
 */
export const WEBGL_USE_SHAPES_UNIFORMS = 'WEBGL_USE_SHAPES_UNIFORMS';
```

will be parsed and the parser will generates the following in target merged json file:
```json
{
  "docInfo": {
    "heading": "Flags",
    "subheading": "WebGL"
   },
  "symbolName": "WEBGL_USE_SHAPES_UNIFORMS",
  "documentation": "Whether we will use shapes uniforms.",
  "fileName": "#52",
  "githubUrl": "https://github.com/tensorflow/tfjs/tree/tfjs-v4.0.0/tfjs-backend-webgl/src/flags_webgl.ts#L52-L66",             
  "isFlag": true,
  "displayName": "WEBGL_USE_SHAPES_UNIFORMS",
  "urlHash": "class:WEBGL_USE_SHAPES_UNIFORMS"
}
```

The HTML (UI) generation codes for the above data object is at https://github.com/tensorflow/tfjs-website/pull/477.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs-website/476)
<!-- Reviewable:end -->
