### PR TITLE
Add tfjs-backend-webgpu to API page

### DIFF
--- a/themes/tfjs/layout/layout.hbs
+++ b/themes/tfjs/layout/layout.hbs
@@ -83,6 +83,7 @@ limitations under the License.
   <script src="{{url_for 'js/vendor/tf.min.js'}}"> </script>
   {{else}}
   <script src="https://cdn.jsdelivr.net/npm/@tensorflow/tfjs@{{page.title}}"> </script>
+  <script src="https://cdn.jsdelivr.net/npm/@tensorflow/tfjs-backend-webgpu@latest"> </script>
   {{/if}}
   {{/if}}
 


### PR DESCRIPTION
Since tensor creation API involves WebGPU backend, we could add WebGPU backend to the website to support users to try WebGPU backend's features.

Since the version of tfjs-backend-webgpu is not same as the version of tfjs union package, we could always use the latest version of it.

Fixed https://github.com/tensorflow/tfjs/issues/7289.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs-website/488)
<!-- Reviewable:end -->
