### PR TITLE
fix: grammar

### DIFF
--- a/docs/guide/platform_environment.md
+++ b/docs/guide/platform_environment.md
@@ -138,7 +138,7 @@ tf.ready().then(() => {...});
 ##### Why WASM?
 
 [WASM](https://webassembly.org/) was introduced in 2015 as a new web-based binary format, providing programs written
-in JavaScript, C, C++, etc. a compilation target for running on the web. WASM has been [supported](https://webassembly.org/roadmap/)
+in JavaScript, C, C++, etc. with a compilation target for running on the web. WASM has been [supported](https://webassembly.org/roadmap/)
 by Chrome, Safari, Firefox, and Edge since 2017, and is supported by [90% of devices](https://caniuse.com/#feat=wasm)
 worldwide.
 


### PR DESCRIPTION
This pull request fixes a grammar mistake that used to make the documentation ambiguous.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs-website/489)
<!-- Reviewable:end -->
