### PR TITLE
Support code snippet running on WebGPU backend

### DIFF
--- a/themes/tfjs/source/js/codeSnippets.js
+++ b/themes/tfjs/source/js/codeSnippets.js
@@ -157,7 +157,7 @@ function initCodeBlocks(selector) {
 
     block.parentElement.insertAdjacentElement('afterend', consoleElement);
 
-    function runCodeSnippet() {
+    consoleRunElement.addEventListener('click', async function() {
       var consoleLogElement =
           this.parentElement.querySelector('.snippet-console-log');
 
@@ -167,16 +167,14 @@ function initCodeBlocks(selector) {
       } else {
         snippetText = this.parentElement.previousElementSibling.innerText;
       }
-      executeCodeSnippet(consoleLogElement, snippetText);
-    }
 
-    if (tf != null && tf.ready != null) {
-      tf.ready().then(() => {
-        consoleRunElement.addEventListener('click', runCodeSnippet);
-      });
-    } else {
-      consoleRunElement.addEventListener('click', runCodeSnippet);
-    }
+      if (tf == null || tf.ready == null) {
+        throw new Error('Failed to load TFJS.');
+      }
+      await tf.ready();
+
+      executeCodeSnippet(consoleLogElement, snippetText);
+    });
 
     consoleEditElement.addEventListener('click', function() {
       makeEditable(block);

--- a/themes/tfjs/source/js/codeSnippets.js
+++ b/themes/tfjs/source/js/codeSnippets.js
@@ -86,7 +86,7 @@ async function executeCodeSnippet(consoleLogElement, codeSnippet) {
   // It is important that codeSnippet and 'try {' be on the same line
   // in order to not modify the line number on an error.
   const evalString = '(async function runner() { try { ' + codeSnippet +
-    '\n} catch (e) { reportError(e); } })()';
+      '\n} catch (e) { reportError(e); } })()';
 
   if (window._tfengine && window._tfengine.startScope) {
     window._tfengine.startScope();
@@ -134,7 +134,7 @@ function makeEditable(codeBlock) {
 function initCodeBlocks(selector) {
   // Find all the code blocks.
   var jsBlocks =
-    Array.prototype.slice.call(document.querySelectorAll(selector));
+      Array.prototype.slice.call(document.querySelectorAll(selector));
 
   jsBlocks.forEach(function(block) {
     var consoleElement = document.createElement('div');
@@ -157,9 +157,9 @@ function initCodeBlocks(selector) {
 
     block.parentElement.insertAdjacentElement('afterend', consoleElement);
 
-    consoleRunElement.addEventListener('click', function() {
+    function runCodeSnippet() {
       var consoleLogElement =
-        this.parentElement.querySelector('.snippet-console-log');
+          this.parentElement.querySelector('.snippet-console-log');
 
       var snippetText;
       if (block.codeMirror) {
@@ -167,9 +167,16 @@ function initCodeBlocks(selector) {
       } else {
         snippetText = this.parentElement.previousElementSibling.innerText;
       }
-
       executeCodeSnippet(consoleLogElement, snippetText);
-    });
+    }
+
+    if (tf != null && tf.ready != null) {
+      tf.ready().then(() => {
+        consoleRunElement.addEventListener('click', runCodeSnippet);
+      });
+    } else {
+      consoleRunElement.addEventListener('click', runCodeSnippet);
+    }
 
     consoleEditElement.addEventListener('click', function() {
       makeEditable(block);


### PR DESCRIPTION
Since WebGPU backend initialization is async, it requires call `tf.ready()` or `tf.setBackend('webgpu')` before usage. Without calling `tf.ready()` or `tf.setBackend(backendName)`, it works for other backends, because all other backends' initializations are sync.

Fix: https://github.com/tensorflow/tfjs/issues/7688