### PR TITLE
Update broken link for Layers API.

### DIFF
--- a/docs/guide/layers_for_keras_users.md
+++ b/docs/guide/layers_for_keras_users.md
@@ -1,7 +1,7 @@
 # TensorFlow.js layers API for Keras users
 
 The Layers API of TensorFlow.js is modeled after Keras and we strive to make the
-[Layers API](https://js.tensorflow.org/api/latest/) as
+[Layers API](https://js.tensorflow.org/api/latest/#Layers) as
 similar to Keras as reasonable given the differences between JavaScript and
 Python. This makes it easier for users with experience developing Keras models
 in Python to migrate to TensorFlow.js Layers in JavaScript. For example, the


### PR DESCRIPTION
I have updated the broken link for Layers API from old link https://js.tensorflow.org/api/latest/ to new link https://js.tensorflow.org/api/latest/#Layers. 
Please do the needful. Thank You !