### PR TITLE
Updated broken urls on save_load.md

### DIFF
--- a/docs/guide/save_load.md
+++ b/docs/guide/save_load.md
@@ -12,9 +12,9 @@ Loading these models are covered in the following two tutorials:
 - [Import Graphdef models](../tutorials/conversion/import_saved_model.md)
 
 
-## Save a tf.Model
+## Save a tf.model
 
-[`tf.Model`](https://js.tensorflow.org/api/0.14.2/#class:Model) and [`tf.Sequential`](https://js.tensorflow.org/api/0.14.2/#class:Model)
+[`tf.model`](https://js.tensorflow.org/api/latest/#model) and [`tf.Sequential`](https://js.tensorflow.org/api/latest/#class:Sequential)
 both provide a function [`model.save`](https://js.tensorflow.org/api/0.14.2/#tf.Model.save) that allow you to save the
 _topology_ and _weights_ of a model.
 


### PR DESCRIPTION
### Updated the documentation with correct url

```
## Save a tf.model
[`tf.model`](https://js.tensorflow.org/api/latest/#model) and [`tf.Sequential`](https://js.tensorflow.org/api/latest/#class:Sequential)
both provide a function [`model.save`](https://js.tensorflow.org/api/0.14.2/#tf.Model.save) that allow you to save the
_topology_ and _weights_ of a model.

``
![Screenshot 2024-09-25 at 12 01 40 AM](https://github.com/user-attachments/assets/40ff2ab4-76c6-479e-a51c-5bb1baa69a24)

